### PR TITLE
fix(ci): Make the build action run on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,9 @@ on:
       - '**.cmake'
       - 'shell.nix'
       - '.github/workflows/build.yml'
-
-
+      - 'vcpkg.json'
+  push:
+    branches: [ "main" ]
 
 jobs:
   set-label:


### PR DESCRIPTION
Fixes a bug that made the Windows runner unable to access the cache