### PR TITLE
fix: FIxes some bugs in the Bus logic

### DIFF
--- a/src/core/wire.cpp
+++ b/src/core/wire.cpp
@@ -165,13 +165,20 @@ void Wire::addUpdateAction(const action_ptr& a)
 
 Bus::Bus(const unsigned short size)
 {
-  this->busData = std::vector(size, std::make_shared<Wire>(State::ERROR));
+  this->busData.reserve(size);
+  for (unsigned short i = 0; i < size; i++)
+    this->busData.push_back(std::make_shared<Wire>(State::ERROR));
 }
 
 void Bus::setSize(const unsigned short size)
 {
-  this->busData.resize(size, std::make_shared<Wire>(State::ERROR));
-  assert(this->busData.size() == size);
+  const size_t oldSize = this->busData.size();
+
+  this->busData.resize(size);
+
+  // `resize` adds nullpointers if the new size is greater, so we need to fill them up
+  for (size_t i = oldSize; i < size; i++)
+    this->busData[i] = std::make_shared<Wire>(State::ERROR);
 }
 
 Bus::Bus(std::vector<Wire_ptr> busData)

--- a/tests/logic.cpp
+++ b/tests/logic.cpp
@@ -189,3 +189,12 @@ TEST(LogicTest, CircuitEditing2) {
   c->forceSetCurrentState(State::LOW);
   EXPECT_EQ(o->getCurrentState(), State::LOW);
 }
+
+TEST(LogicTest, BusSettingReading)
+{
+  auto a = Bus(4);
+  for (int i = 0; i <= 0b1111; i++) {
+    a.forceSetCurrentValue(i);
+    EXPECT_EQ(a.getCurrentValue(), i);
+  }
+}

--- a/tests/tests.hpp
+++ b/tests/tests.hpp
@@ -20,3 +20,13 @@ inline void __tsan_on_report() {
     FAIL() << "Encountered a thread sanitizer error";
   }
 }  // extern "C"
+
+void PrintTo(const State& s, std::ostream* os)
+{
+  switch (s) {
+    case State::HIGH: *os << "HIGH"; break;
+    case State::LOW: *os << "LOW"; break;
+    case State::ERROR: *os << "ERROR"; break;
+    default: assert(false);
+  }
+}


### PR DESCRIPTION
There was a bug that was making all the tests involving buses, because `std::vector(n, val)` initializes the vector with n copies of the same `val` object.